### PR TITLE
Fix a strange dynamic array test

### DIFF
--- a/DynamicAnalyzer/src/main/java/testclasses/ArrayRefSuccess.java
+++ b/DynamicAnalyzer/src/main/java/testclasses/ArrayRefSuccess.java
@@ -11,13 +11,13 @@ public class ArrayRefSuccess {
 
 	public static void main(String[] args) {
 		String secret = read()[1];
-		String[] pub = {"x", "y", DynamicLabel.makeLow(secret)};
+		String[] pub = {"x", "y", secret};
 		System.out.println(pub[2]);
 	}
 
 	public static String[] read() {
 		String secret = "42";
-		secret = DynamicLabel.makeHigh(secret);
+		secret = DynamicLabel.makeLow(secret);
 		return new String[]{"41", secret, "43"};
 	}
 	


### PR DESCRIPTION
Hi Ravisha,

Again a very late reply, I'm sorry.
The test that was failing was very strange... it did apply both of the special functions DynamicLabel.makeHigh and DynamicLabel.makeLow to a single value.. I'm not even sure what the result of this should be or what the author (Nicolas) was trying to test)
I fixed it s.t. it makes more sense to me: only applying DynamicLabel.makeLow. Now it works. I think that's fine, as we should not use the DynamicLabel.* functions in the full system anyway (i.e. the full system with type-checking and casts added, not just the DynamicAnalyzer)

I hope this helps. Sorry again for keeping you waiting.